### PR TITLE
Match grammar path case to actual filename case

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
             {
                 "language": "junos",
                 "scopeName": "text.junos",
-                "path": "./syntaxes/junos.tmLanguage"
+                "path": "./syntaxes/Junos.tmLanguage"
             }
         ]
     }


### PR DESCRIPTION
This fixes the extension to work on Ubuntu and other operating systems where the filesystem is case sensitive.  Otherwise, VSCode can't find the grammar file and the entire extension fails to load.

Fixes #5 
